### PR TITLE
Add rock-style schedule webpage

### DIFF
--- a/generate_ics.js
+++ b/generate_ics.js
@@ -1,0 +1,54 @@
+const fs = require('fs');
+const schedule = JSON.parse(fs.readFileSync('schedule.json', 'utf8'));
+
+const days = {
+  friday: { date: '20250725' },
+  saturday: { date: '20250726' },
+  sunday: { date: '20250727' }
+};
+
+function parseTime(timeStr) {
+  const [hm, ampm] = timeStr.split(' ');
+  let [h, m] = hm.split(':').map(Number);
+  if (ampm.toUpperCase() === 'PM' && h !== 12) h += 12;
+  if (ampm.toUpperCase() === 'AM' && h === 12) h = 0;
+  return { h, m };
+}
+
+function pad(n) { return n.toString().padStart(2, '0'); }
+
+function formatDate(date, time) {
+  return `${date}${pad(time.h)}${pad(time.m)}00`;
+}
+
+let out = `BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//Open Sauce Schedule//EN`;
+
+for (const [dayName, { date }] of Object.entries(days)) {
+  const events = schedule[dayName] || [];
+  for (const ev of events) {
+    const startTime = parseTime(ev.time);
+    const start = formatDate(date, startTime);
+    const length = parseInt(ev.length || '30', 10);
+    const endDate = new Date(Date.UTC(
+      Number(date.slice(0,4)),
+      Number(date.slice(4,6)) - 1,
+      Number(date.slice(6,8)),
+      startTime.h,
+      startTime.m
+    ));
+    const endDateObj = new Date(endDate.getTime() + length * 60000);
+    const end = `${endDateObj.getUTCFullYear()}${pad(endDateObj.getUTCMonth()+1)}${pad(endDateObj.getUTCDate())}${pad(endDateObj.getUTCHours())}${pad(endDateObj.getUTCMinutes())}00`;
+
+    const descriptionParts = [];
+    if (ev.description) descriptionParts.push(ev.description);
+    const speakerNames = (ev.speakers || []).map(s => s.name).join(', ');
+    if (speakerNames) descriptionParts.push('Speakers: ' + speakerNames);
+    if (ev.moderator && ev.moderator.name) descriptionParts.push('Moderator: ' + ev.moderator.name);
+    const description = descriptionParts.join('\n').replace(/\n/g,'\\n');
+
+    out += `\nBEGIN:VEVENT\nSUMMARY:${ev.title}\nDTSTART:${start}\nDTEND:${end}\nDESCRIPTION:${description}\nLOCATION:${ev.where}\nEND:VEVENT`;
+  }
+}
+
+out += '\nEND:VCALENDAR\n';
+fs.writeFileSync('schedule.ics', out);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Open Sauce Schedule</title>
+  <link href="https://fonts.googleapis.com/css2?family=Metal+Mania&display=swap" rel="stylesheet">
+  <style>
+    body {
+      margin: 0;
+      font-family: Arial, sans-serif;
+      background: #111;
+      color: #eee;
+    }
+    header {
+      text-align: center;
+      padding: 1em;
+      background: #000;
+    }
+    h1 {
+      font-family: 'Metal Mania', cursive;
+      color: #e53935;
+      margin: 0 0 0.5em 0;
+      font-size: 2.5em;
+    }
+    a.button {
+      display: inline-block;
+      margin-top: 0.5em;
+      padding: 0.5em 1em;
+      background: #e53935;
+      color: #fff;
+      text-decoration: none;
+      border-radius: 4px;
+      font-weight: bold;
+    }
+    section {
+      padding: 1em;
+    }
+    section h2 {
+      font-family: 'Metal Mania', cursive;
+      color: #e53935;
+      font-size: 2em;
+      margin-top: 1em;
+      border-bottom: 1px solid #444;
+    }
+    .event {
+      margin: 0.5em 0 1.5em 0;
+      padding-bottom: 1em;
+      border-bottom: 1px dashed #444;
+    }
+    .event h3 {
+      margin: 0;
+      font-size: 1.2em;
+      color: #fff;
+    }
+    .time {
+      color: #ff9800;
+      font-weight: bold;
+    }
+    .where {
+      font-style: italic;
+      color: #ccc;
+    }
+    @media (min-width: 600px) {
+      body { font-size: 18px; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Open Sauce 2025</h1>
+    <a class="button" href="schedule.ics" download>Download Schedule (ICS)</a>
+  </header>
+  <div id="schedule"></div>
+  <script>
+    fetch('schedule.json')
+      .then(res => res.json())
+      .then(data => {
+        const days = [
+          ['friday', 'Friday July 25'],
+          ['saturday', 'Saturday July 26'],
+          ['sunday', 'Sunday July 27']
+        ];
+        const container = document.getElementById('schedule');
+        days.forEach(([key, label]) => {
+          const daySec = document.createElement('section');
+          const h2 = document.createElement('h2');
+          h2.textContent = label;
+          daySec.appendChild(h2);
+          (data[key] || []).forEach(ev => {
+            const div = document.createElement('div');
+            div.className = 'event';
+            const title = document.createElement('h3');
+            title.textContent = ev.title;
+            const time = document.createElement('div');
+            time.className = 'time';
+            time.textContent = `${ev.time} \u2013 ${ev.where}`;
+            const desc = document.createElement('p');
+            desc.textContent = ev.description || '';
+            div.appendChild(title);
+            div.appendChild(time);
+            if (ev.description) div.appendChild(desc);
+            daySec.appendChild(div);
+          });
+          container.appendChild(daySec);
+        });
+      });
+  </script>
+</body>
+</html>

--- a/schedule.ics
+++ b/schedule.ics
@@ -1,0 +1,494 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Open Sauce Schedule//EN
+BEGIN:VEVENT
+SUMMARY:Welcome to Open Sauce with William Osman
+DTSTART:20250725093000
+DTEND:20250725094000
+DESCRIPTION:Join the official kickoff of Open Sauce Year 3 with inventor and creator William Osman. This session will offer a quick look at the creator culture that drives innovation, audience connection, and creative business growth.\nSpeakers: Jim Louderback, William Osman
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Scaling Content Across Borders
+DTSTART:20250725094000
+DTEND:20250725100500
+DESCRIPTION:As platforms grow globally, smart creators are discovering opportunity to distribute everywhere. This session lays out the advantages for global content expansion: greater ad revenue, new sponsorship options, and increased audience growth. Learn which tools, partners, and platforms are helping creators scale internationally - without scaling production.\nSpeakers: Dustin Harris, Jonny Steel, Corey Braun
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:If YouTube Died Tomorrow, Would Your Business?
+DTSTART:20250725100500
+DTEND:20250725103500
+DESCRIPTION:You don’t own your followers. And if the algorithm turns on you—or your platform disappears—what happens next? This session explores how creators are future-proofing their business by owning their audiences and monetizing beyond the core social platforms. Learn how to take control of your community, revenue, and future - and stop relying on rented land.\nSpeakers: Kevin Daigle, Luria Petrucci, Brian McManus, Luke Lafreniere, Christian Eveleigh
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Fireside Chat with Alex Wellen, President QVC
+DTSTART:20250725103500
+DTEND:20250725110000
+DESCRIPTION:Commerce has entered a bold new era. As the original disruptor in retail innovation, QVC Group is building the future of live, social, and immersive shopping. In this fireside chat, Alex Wellen, President and Chief Growth Officer of QVC Group, joins Jim Louderback to explore how the company is redefining the commerce experience—scaling authentic storytelling, reaching new consumers, empowering fresh voices, and setting the standard for the future of shoppable media across all types of products – including those from makers, builders, scientists and geeks.\nSpeakers: Jim Louderback, Alex Wellen
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Fireside Chat with Kevin Kelly and William Osman
+DTSTART:20250725110000
+DTEND:20250725113000
+DESCRIPTION:Kevin Kelly helped define digital optimism and shaped how we think about technology, communities, and creativity. In this live podcast recording and fireside chat with maker-creator William Osman, the Wired founding executive editor explore the real meaning behind 1,000 True Fans, the power of an “audience of one,” and why a little optimism is a good thing. Expect stories, frameworks, and timeless advice for everyone navigating the next era of the internet and life itself.\nSpeakers: William Osman
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:The Science of Memes and the Art of Relevance
+DTSTART:20250725113000
+DTEND:20250725120000
+DESCRIPTION:What do an etymology expert and an engineering creator have in common? Memes. In this surprising and fun session, Etymology Nerd Adam Aleksic and Patrick Lacey from Tier Zoo explore how meme culture powers both virality and connection. From shifting language to unexpected content formats, they’ll explore what it really takes to stay relevant—and respected—online. You’ll learn how to spot high-potential trends early, apply meme logic to serious content, and use humor to build lasting audience engagement.\nSpeakers: Adam Aleksic, Patrick Lacey, Morgan Sung
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:LUNCH
+DTSTART:20250725120000
+DTEND:20250725130000
+DESCRIPTION:
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Roundtable with Tyler Chou
+DTSTART:20250725122000
+DTEND:20250725125000
+DESCRIPTION:Got a legal question? Wondering abou the law and creators? Bring your questions, thoughs and ideas to this round-table discussion with creator, lawyer, manager and creator advocate Tyler Chou.\nSpeakers: Tyler Chou
+LOCATION:Breakout 3
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:AMA With NASA Astronaut Matthew Dominick
+DTSTART:20250725122000
+DTEND:20250725125000
+DESCRIPTION:Straight from NASA to our stage, Matthew Dominick answers your boldest, weirdest, and most ambitious space questions - along with talking about what it's like to be a creator in space.\nSpeakers: Matthew Dominick
+LOCATION:Breakout 1
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:A Day in the life of Mark Rober's Creative Team
+DTSTART:20250725122000
+DTEND:20250725125000
+DESCRIPTION:Go behind the scenes with Mark Rober’s creative team as they share insights into their workflow, problem-solving techniques, and the magic behind their viral projects. Bring your questions and ideas to this interactive AMA session and explore wild ideas, innovative production processes and more!\nSpeakers: Pojo Riegert, Jon Marcu
+LOCATION:Breakout 2
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:YouTube Algorithm Secrets - 2025
+DTSTART:20250725130000
+DTEND:20250725133000
+DESCRIPTION:YouTube's creator liaison and editor Rene Ritchie and YouTube product manager Todd Beaupre know more about building success on YouTube than just about anyone else. In this session they'll share the deep secrets of success for July 2025, including why the algorithm doesn't hate you, how AI is changing discovery and recommendations, the key numbers and KPIs to REALLY focus on, the unique characteristics of Shorts, YouTube on the big screen and much more! Get ready to really understand how the YouTube algorithm works from the inside experts at YouTube!\nSpeakers: Todd Beaupré, Rene Ritchie, Gwen Miller
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:GM's Creator Playbook
+DTSTART:20250725133000
+DTEND:20250725135500
+DESCRIPTION:For GM, the road to the future isn’t just about EVs and autonomous driving – it’s about transforming how they engage with creators and redefine their brand for a digital-first world. Jessica Wang, Executive Director of Content Strategy at GM and former YouTube executive, shares how the legacy automaker is moving beyond traditional influencer campaigns to deeper, more authentic partnerships that treat creators like true creative collaborators. Learn why GM is betting on creators as strategic storytellers, how they’re building relationships beyond the automotive world, and what this approach means for brands looking to connect with diverse, engaged audiences.\nSpeakers: Jessica Wang, Neil Waller
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:What Creators Wish Brands Knew
+DTSTART:20250725135500
+DTEND:20250725142500
+DESCRIPTION:Brands love working with creators—until they don’t. Misaligned expectations, bad briefs, and clunky approval processes can turn a dream deal into a disaster. In this session, top creators pull back the curtain on what brands get wrong (and right) when collaborating with influencers. From creative freedom to fair pay to authentic storytelling, hear firsthand what creators need from brands to deliver their best work—and why some partnerships fail before they even begin. If you’re a brand looking to build better, more effective creator relationships, this is the conversation you can’t afford to miss.\nSpeakers: Cassandra Bankson, Monica Khan
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:What Brands Wish Creators Knew - Kamal Bhandal
+DTSTART:20250725142500
+DTEND:20250725145000
+DESCRIPTION:What makes a creator stand out—or get cut? Kamal Bhandal, SVP of Global Invisalign Brand at Align Technology, shares what brands really look for, what kills a deal, and how creators can position themselves for long-term partnerships. Walk away with clear, insider tips to land brand deals and avoid common missteps.\nSpeakers: Kamal Bhandal, Eric Wei
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Thriving as a Creator in the Age of AI
+DTSTART:20250725145000
+DTEND:20250725152000
+DESCRIPTION:These creators aren’t scared of AI, they're adapting and thriving. 3 top creators share how they are integrating AI into their workflows today, and how they plan to differentiate their content from AI-generated slop tomorrow. From content production to audience growth, new formats and digital twins, they’ll share what tools are working, what’s still broken, and how they'll collaborate and compete with AI in the future.\nSpeakers: YC Sun, Delia Lazarescu, Rox Codes
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:AFTERNOON BREAK
+DTSTART:20250725153000
+DTEND:20250725161000
+DESCRIPTION:
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Round Table With Rene Ritchie
+DTSTART:20250725153500
+DTEND:20250725160500
+DESCRIPTION:Join this round table / AMA with Rene Ritchie to talk YouTube algorithms, creating content and really anything on your mind!\nSpeakers: Todd Beaupré, Rene Ritchie
+LOCATION:Breakout 1
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Round Table Q&A: Setting Yourself Up for Brand Partnerships Success
+DTSTART:20250725153500
+DTEND:20250725160500
+DESCRIPTION:This facilitated discussion brings creators together to unpack the full brand partnerships journey. Whether you're represented or independent, you'll walk through the entire cycle—from strategy to pitch to execution and renewal. Guided by Ben Smith from Smooth Media, you’ll learn how to better define your audience, build effective media kits, and sustain long-term relationships. Share your experience, ask questions, and leave with tactical insights to help you start working with your dream brands.\nSpeakers: Ben Smith
+LOCATION:Breakout 3
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Roundtable Conversation: What is a Creator in the Age of AI
+DTSTART:20250725153500
+DTEND:20250725160500
+DESCRIPTION:AI is reshaping the creative process. This roundtable, led by YC Sun and Dan Perkel of IDEO, offers an interactive forum for creators, marketers and experts to discuss the practical, personal, and ethical questions raised in “Thriving as a Creator in the Age of AI.” Bring your ideas, frustrations, questions and code. You'll leave with new strategies, peer insights, and possible collaborations.\nSpeakers: YC Sun, Dan Perkel
+LOCATION:Breakout 2
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Explaining the Universe One Click at a Time
+DTSTART:20250725161000
+DTEND:20250725164000
+DESCRIPTION:From backyard explosions to big-bang theories, science hits different when it’s told by creators who love to tinker, test, and ask “what if?” This session dives into how hands-on creators and lifelong explainers are turning curiosity into content that sticks—and why making people feel science might matter more than making them memorize it. Get practical strategies to create, build, fund, and scale science communication in a platform-first world.\nSpeakers: Matthew Dominick, Ian Charnas, Trace Dominguez
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:From Tech Journalist to Brand Insider
+DTSTART:20250725164000
+DTEND:20250725170500
+DESCRIPTION:Dan Ackerman spent years running major tech sites, including Gizmodo and CNET. Now he’s internal editor-in-chief at MicroCenter. What’s it like to go from covering the industry to working inside it? Joined by creator and MicroCenter SuperFan Michael Reeves, this session explores the evolving role of media, the rise of internal creators, and what the future looks like for building PCs and telling tech stories.\nSpeakers: Dan Ackerman, Michael Reeves
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Likes Don’t Pay Rent - Fireside Chat with Patreon COO Paige Fitzgerald
+DTSTART:20250725170500
+DTEND:20250725173000
+DESCRIPTION:This fireside chat with Patreon COO Paige Fitzgerald explores how creators are moving beyond ad models and algorithm churn to build real, recurring revenue. Drawing on insights from Patreon’s latest State of the Creator report and real world examples, the session will explore what sustainable success looks like today. Whether you're a creator, a platform builder, or a brand investing in talent, this conversation offers a clear look at what it takes to build a lasting creative business.\nSpeakers: Paige Fitzgerald
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:From YouTube Clickbait to Real Engineering
+DTSTART:20250725173000
+DTEND:20250725180000
+DESCRIPTION:We’re closing out industry day with a conversation with top creators who are pushing the boundaries of internet innovation through hands-on engineering and practical product development. From prototyping physical products to launching new tools with AI, this session dives into the serious side of making on the internet. You'll leave with insight into how creators are evolving beyond content into real-world problem-solving and what’s inspiring them to keep building.\nSpeakers: William Osman
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Industry Reception
+DTSTART:20250725183000
+DTEND:20250725203000
+DESCRIPTION:
+LOCATION:Off-Site
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Safety Third: LIVE!
+DTSTART:20250726103000
+DTEND:20250726111500
+DESCRIPTION:Safety Third but it's LIVE! The hosts (and some guests) share stories and rant while pretending to talk about science.\nSpeakers: NileRed, The Backyard Scientist, William Osman, Michael Reeves, Emily The Engineer
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Innovating In A Niche
+DTSTART:20250726110000
+DTEND:20250726113000
+DESCRIPTION:Some people chase trends, but these creators have built strong, loyal audiences by sticking to what they love and finding others who love it too. Hear how to turn niche ideas into standout content.\nSpeakers: Engineezy, Ali Spagnola, Alan Becker, Gavin Free
+LOCATION:Outdoor Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Prototyping to Product
+DTSTART:20250726111500
+DTEND:20250726114500
+DESCRIPTION:Making one cool thing for a YouTube video is tough enough, but turning that idea into 10,000 units is a whole different challenge. Learn how these creators have taken their custom-built projects from prototype to product.\nSpeakers: The Hacksmith, Jake Laser, JerryRigEverything, Unnecessary Inventions, Stephen Hawes\nModerator: Ruth Amos
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:The BackYard - Agains
+DTSTART:20250726120000
+DTEND:20250726124500
+DESCRIPTION:We’re back! Join as the cast of The Yard returns for more Backyard Science in the squeak-uel we've all been waiting for.\nSpeakers: Ludwig, Nick, Slime\nModerator: The Backyard Scientist
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Team Rocket
+DTSTART:20250726124500
+DTEND:20250726133000
+DESCRIPTION:Join us to nerd out over thrust vectors, propellants, shock diamonds, and more rocket words! It's gonna rock(et).\nSpeakers: BPS.space, Integza, SmarterEveryDay, Scott Manley, Brigette Oakes\nModerator: Brian McManus
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Robotics and Animatronics!
+DTSTART:20250726130000
+DTEND:20250726133000
+DESCRIPTION:What if the robots could move?\nSpeakers: Odd_Jayy, Kiara’s Workshop, Wicked Makers, Becky Stern, Aaed Musa\nModerator: Mr. Volt
+LOCATION:Outdoor Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Could AI Make This Panel?
+DTSTART:20250726133000
+DTEND:20250726140000
+DESCRIPTION:It - made - this - description!\nSpeakers: Jabrils, Captain Disillusion, ThePrimeagen, Luke Lafreniere\nModerator: Theo
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Planes, Trains, and Automobiles
+DTSTART:20250726133000
+DTEND:20250726141500
+DESCRIPTION:Walking is overrated. This gang of creators prefers to drive, fly and float their way around.\nSpeakers: Peter Sripol, Tom Stanton, rctestflight, Ramy RC, Aging Wheels, Quiet Nerd\nModerator: Louis Weisz
+LOCATION:Outdoor Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:It's All About Chemistry
+DTSTART:20250726133000
+DTEND:20250726140000
+DESCRIPTION:We all know "Chemistry is the scientific study of matter, its properties, and how it changes during chemical reactions. It explores the building blocks of the universe such as atoms and molecules and how they interact to form everything from water to DNA. Chemistry connects the physical world with biological and environmental systems", and this panel connects you with your favorite chemistry creators. Will they bond?\nSpeakers: NileRed, Cody's Lab, Explosions&Fire, Styropyro, The Thought Emporium\nModerator: William Osman
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Streaming AMA
+DTSTART:20250726140000
+DTEND:20250726143000
+DESCRIPTION:It doesn't get more live than this. Chat with top streaming creators in this Q&A panel. Questions for the panel must be submitted in advance via the event app.\nSpeakers: Bao The Whale, Codemiko, DisguisedToast, Sydeon, Yvonnie, Scarra\nModerator: PointCrow
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Let's make a game in an hour
+DTSTART:20250726140000
+DTEND:20250726150000
+DESCRIPTION:Speakers: Kevin Laird
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Unconventional Materials
+DTSTART:20250726141500
+DTEND:20250726144500
+DESCRIPTION:Wood, metal, and plastic are fine...but why stop there? How to make something from anything.\nSpeakers: Peter Brown, Bobby Duke Arts, Morley Kert, Ali Spagnola, Crescent Shay\nModerator: Nate From the Internet
+LOCATION:Outdoor Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:State of The Union
+DTSTART:20250726143000
+DTEND:20250726150000
+DESCRIPTION:Over the past two decades, content creation has evolved from webcam vlogs into a multi-billion-dollar industry. Join us as we chat about the shifts in platforms, audiences, algorithms, and where we might be headed next.\nSpeakers: Hank Green, Vsauce, Gavin Free, Arin Hanson\nModerator: Jim Louderback
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Super Villain Inc.
+DTSTART:20250726150000
+DTEND:20250726153000
+DESCRIPTION:Trapped in an entry level job, creators are forced to innovate at the will of an evil corporate overlord. Watch as they navigate a game of ethics, corporate bureaucracy, and the laws of physics. Will there be synergy?\nSpeakers: Colin Furze, Styropyro, Michael Reeves, Allen Pan, ElectroBOOM\nModerator: Alex Ernst
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Meet the Bot Builders, ask them anything!
+DTSTART:20250726151500
+DTEND:20250726160000
+DESCRIPTION:A discussion with some of the most famous builders in BattleBots. We will talk about BattleBots Faceoffs and some recent YouTube creators and bot builders collaborations then open it up to questions. Builders: Ray Billings: Tombstone (World Champion and Most Destructive Robot Award), Leanne Cushing: Valkyrie (Most Destructive Robot Award), Nick Dobrikov: Manta, Jen Herochender: Hijinx, Aren Hill: Tantrum, Blip (World Champion), Bunny Liaw: Malice, Zach Lytle: Skorpios and Derek Tran: Cobalt, Gigabyte\nModerator: Peter Abrahamson
+LOCATION:Outdoor Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Why you need a producer
+DTSTART:20250726153000
+DTEND:20250726163000
+DESCRIPTION:Speakers: Matt Warl
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Carp Tank
+DTSTART:20250726160000
+DTEND:20250726164500
+DESCRIPTION:Open Sauce exhibitors team up with creators to pitch their projects to a panel of vicious business carp. Will the ideas (and their inventors) sink or swim under the pressure?\nSpeakers: William Osman, TechJoyce, Unnecessary Inventions, Kyle Hill, Evan and Katelyn, Ruth Amos\nModerator: InternetCommentEtiquette
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:gnireenignE: Reverse Engineering
+DTSTART:20250726163000
+DTEND:20250726170000
+DESCRIPTION:.gnireenigne s'taht won ,rehtegot kcab meht gnittup ,trapA sgniht gnikaT\nSpeakers: Strange Parts, Jeff Geerling, Ben Krasnow, Ben Eater, Jeremy Fielding\nModerator: Stephen Hawes
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:3D Printing Hot Takes
+DTSTART:20250726170000
+DTEND:20250726173000
+DESCRIPTION:From failed first layers, to funky filaments, and a billion “Benchy’s”: these creators' and their 3D printing opinions are like onions (they have layers). Join them for a layered discussion about printers, slicers, and so many layers.\nSpeakers: CNC Kitchen, Thomas Sanladerer, Emily The Engineer, Allen Pan\nModerator: 3D Printing Nerd
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Are you dumber than a sixth grader?
+DTSTART:20250726170000
+DTEND:20250726174500
+DESCRIPTION:Four creators vs four sixth graders. Who will win?\nSpeakers: NileRed, SmarterEveryDay, Atarabyte, Ted Nivison\nModerator: Hank Green
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Doing It The Hard Way (Ye' Olde Makers)
+DTSTART:20250726173000
+DTEND:20250726180000
+DESCRIPTION:Ignoring the advances of technology over the past few decades is… a choice.\nSpeakers: Cody's Lab, How To Make Everything, Bobby Duke Arts, FarmCraft101
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:YouTube Shop Talk: Ask Us Anything!
+DTSTART:20250727103000
+DTEND:20250727110000
+DESCRIPTION:Talk shop with top creators in this Q&A panel. Questions for the panel must be submitted in advance via the event app.\nSpeakers: Estefannie, CNC Kitchen, Luke Lafreniere, Grady Hillhouse, Skip the Tutorial\nModerator: Trace Dominguez
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Movie Magic: VFX
+DTSTART:20250727103000
+DTEND:20250727110000
+DESCRIPTION:These magicians WILL share their secrets.\nSpeakers: Nick Laurant, Captain Disillusion, Sam Wickert, Brendan Forde\nModerator: Wren
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Experimental Panel Title
+DTSTART:20250727104500
+DTEND:20250727113000
+DESCRIPTION:Never let them know your next move. When these creators post, you never know what you’re gonna get. Come learn about how a sidequest can spiral into something bigger and what to do when you’re interested in everything.\nSpeakers: The Action Lab, Waterjet Channel, NightHawkInLight, Alpha Phoenix, The Thought Emporium, Joel Creates\nModerator: Matthew Harris
+LOCATION:Outdoor Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Mammoth Mistake? Conservation and Human Interference
+DTSTART:20250727110000
+DTEND:20250727113000
+DESCRIPTION:From ancient extinction to modern ecosystems, the line between conservation and interference is blurrier than ever. Should we bring species back? How do we protect what’s still here? And what role should humans play in shaping nature’s future?\nSpeakers: Maya Higa, Emily Graslie, TierZoo\nModerator: Hank Green
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Developing Content on Developing Games
+DTSTART:20250727111500
+DTEND:20250727114500
+DESCRIPTION:These creators know it ain’t all fun and games. Find out how these developer creators juggle developing games and developing content about developing games as this panel develops.\nSpeakers: SonderingEmily, Code Bullet, PolyMars, Luke Muscat\nModerator: Jabrils
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:The Future of Animation
+DTSTART:20250727114500
+DTEND:20250727121500
+DESCRIPTION:From hand-drawn cells to AI-assisted workflows, animation is evolving faster than ever. This panel brings together creators who are pushing the boundaries of style, technology, and storytelling. Explore where animation is headed, how it is being made, and what the next generation of animators and audiences can expect.\nSpeakers: TheOdd1sOut, Rebecca Parham, CircleToonsHD, illymation, Alan Becker, Audity\nModerator: GingerPale
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Learning is Fun: Educating on Educational Content
+DTSTART:20250727121500
+DTEND:20250727130000
+DESCRIPTION:Science education doesn’t have to be dry. Learn how these creators navigate mixing entertainment with education.\nSpeakers: Tibees, TierZoo, Grady Hillhouse, Emily Graslie, ChubbyEmu, The Coding Train, Astro Alexandra\nModerator: Kyle Hill
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Creator Feud
+DTSTART:20250727124500
+DTEND:20250727133000
+DESCRIPTION:Join us for a second annual game of Creator Feud, where your answers shape the game! Be sure to complete our survey before the show to contribute to the pool of responses.\nSpeakers: PointCrow, Slimecicle, Ranboo, ConnorEatsPants, ThePrimeagen, Explosions&Fire, Nerdforge, Allen Pan, ElectroBOOM, Technology Connections\nModerator: Ted Nivison
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:LEGO - Building a Career
+DTSTART:20250727131500
+DTEND:20250727134500
+DESCRIPTION:Come learn how these panelists took their passion for building LEGO and turned it into a career. From corporate displays, to movies, to art.\nSpeakers: Brandon Griffith, Tommy Williamson, Chris Wight, Sam Builds\nModerator: Peter Abrahamson
+LOCATION:Outdoor Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Short Form Content
+DTSTART:20250727133000
+DTEND:20250727141500
+DESCRIPTION:Why use many word when few do trick?\nSpeakers: AstroKobi, Emily The Engineer, Unnecessary Inventions, Atarabyte, Joseph’s Machines, Rachel Pizzolato
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Indie Dev Roundtable "What makes a great demo"
+DTSTART:20250727134500
+DTEND:20250727141500
+DESCRIPTION:Speakers: Gemporium Devs
+LOCATION:Outdoor Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Backyard Science: Touching Grass
+DTSTART:20250727141500
+DTEND:20250727150000
+DESCRIPTION:OfflineTV goes offline to help the Backyard Scientist explore some live stage science.\nSpeakers: Michael Reeves, QuarterJade, Masayoshi, LilyPichu, Pokimane\nModerator: The Backyard Scientist
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:4D Printing
+DTSTART:20250727141500
+DTEND:20250727144500
+DESCRIPTION:Join for a discussion of functional 3D printing, where parts have to play nice with each other and come together to form intricate sculptures and robust machines.\nSpeakers: Sean Hodgins, Engineezy, Ivan Miranda, 3D Printing Nerd\nModerator: Strange Parts
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:The Creative Process
+DTSTART:20250727144500
+DTEND:20250727151500
+DESCRIPTION:Ideas are hard. From inspiration to execution, get an inside look at the creative journey behind the content.\nSpeakers: Evan and Katelyn, Ten Hundred, Nerdforge, TheOdd1sOut\nModerator: Wren
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Farmer Consulting
+DTSTART:20250727151500
+DTEND:20250727154500
+DESCRIPTION:Two “farmers” and one farmer walk into a panel…\nSpeakers: William Osman, The Backyard Scientist, FarmCraft101
+LOCATION:Outdoor Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Long Term Projects
+DTSTART:20250727151500
+DTEND:20250727154500
+DESCRIPTION:Boats, bunkers, and beyond! Creators discuss their multi-part projects and try to convince you that they really will finish them someday. They swear.\nSpeakers: Nate From the Internet, Peter Sripol, Colin Furze, Brent Underwood, Quiet Nerd, How To Make Everything\nModerator: William Osman
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Cosplay: Making From Pop Culture
+DTSTART:20250727151500
+DTEND:20250727154500
+DESCRIPTION:These creators never learned the “fi” part of “sci-fi”. Join for a discussion of making the unreal, real and the metaphysical, physical.\nSpeakers: Stella Chuu, Crescent Shay, LittleJem, Sam Meeps, Kiara’s Workshop\nModerator: Emily The Engineer
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Pitching Your Game to Publishers
+DTSTART:20250727154500
+DTEND:20250727164500
+DESCRIPTION:Speakers: Offbrand Games, Akupara
+LOCATION:Outdoor Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Space (intentionally left blank)
+DTSTART:20250727154500
+DTEND:20250727161500
+DESCRIPTION:Look up, and keep going for 60 something miles (100km).\nSpeakers: AstroKobi, Astro Alexandra, Scott Manley, Brian McManus, Matthew Dominick\nModerator: Everyday Astronaut
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Narrative-first YouTube Channel
+DTSTART:20250727160000
+DTEND:20250727163000
+DESCRIPTION:Anyone who has built something and thought about making a YouTube video about it knows that building is only half the challenge. Telling a story around it is the other. Learn how they document the process, shape compelling stories, and turn complex projects into videos people want to watch.\nSpeakers: Sean Hodgins, Jake Laser, Allen Pan\nModerator: Louis Weisz
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Deep Dives: The Art of Saying More
+DTSTART:20250727161500
+DTEND:20250727164500
+DESCRIPTION:Sometimes you just can’t fit everything into a TikTok. Long-form content gives creators space to explore complex topics and tell richer stories. This panel explores the craft of going deep: from research and storytelling, to keeping viewers engaged for the long haul.\nSpeakers: Technology Connections, Tibees, Alpha Phoenix, Hbomberguy, Ted Nivison\nModerator: BPS.space
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:You Don't Need to Crunch
+DTSTART:20250727163000
+DTEND:20250727170000
+DESCRIPTION:Speakers: PolyMars
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Man vs. Machining
+DTSTART:20250727164500
+DTEND:20250727171500
+DESCRIPTION:Taking a chip off the old block, literally. These creators harness giant metal machines to make (and break) precision parts. Stick around for thoughts on CNC-ing and machining with plenty of jargon along the way.\nSpeakers: Jeremy Fielding, Inheritance Machining, Marius Hornberger, Tom Stanton\nModerator: Breaking Taps
+LOCATION:Outdoor Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Voyagers of Nera Developers
+DTSTART:20250727170000
+DTEND:20250727174500
+DESCRIPTION:
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Scare The Coyote: LIVE!
+DTSTART:20250727171500
+DTEND:20250727180000
+DESCRIPTION:Join the cast and creators of Scare the Coyote for an exclusive live conversation and the inaugural live Golden Coyote Ceremony.\nSpeakers: Alex Ernst, Jabrils, Styropyro, Michael Reeves, NileRed, The Backyard Scientist, Emily The Engineer\nModerator: William Osman
+LOCATION:Main Stage
+END:VEVENT
+END:VCALENDAR


### PR DESCRIPTION
## Summary
- add script `generate_ics.js` to convert `schedule.json` into `schedule.ics`
- generate an iCalendar file of the schedule
- create `index.html` using a rock-band theme that fetches the JSON and shows each day's events

## Testing
- `node generate_ics.js`

------
https://chatgpt.com/codex/tasks/task_b_688b98822bfc8323add6f974d9bdaebe